### PR TITLE
fix yaml whitespace error

### DIFF
--- a/feedspora.yml.template
+++ b/feedspora.yml.template
@@ -5,7 +5,7 @@ accounts:
     pod: 'diaspora_pod_url'
     username: 'username'
     password: 'password'
-		keywords: '' # coma-separated list of keywords to use as hashtag, in addition to those retrieved from the feed.
+    keywords: '' # coma-separated list of keywords to use as hashtag, in addition to those retrieved from the feed.
 
   # You can generated your tokens/secrets for twitter from https://apps.twitter.com
   - name: 'Twitter'


### PR DESCRIPTION
yaml.scanner.ScannerError: while scanning for the next token
found character '\t' that cannot start any token
  in "feedspora.yml", line 8, column 1