### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.6
+LABEL maintainer="Strubbl-dockerfile@linux4tw.de"
+
+ENV DATA_DIR /data
+RUN \
+     mkdir $DATA_DIR \
+  && pip install git+https://github.com/aurelg/shaarpy.git \
+  && git clone https://github.com/aurelg/feedspora.git \
+  && cd feedspora \
+  && pip install -r requirements.txt \
+  && python setup.py install
+
+WORKDIR $DATA_DIR
+CMD ["python", "-m", "feedspora"]
+


### PR DESCRIPTION
This commit adds a docker receipt. You can make use of it with creating
a `feedspora.yml` on your local machine e.g. in `/data/feedsporai/`.
Afterwards the following docker commands will build the image and run
feedspora with your `feedspora.yml`

```
docker build --pull -t $USER_feedspora .
docker run -v /data/feedspora:/data $USER_feedspora
```