### PR TITLE
Enhancement/twitter post limits

### DIFF
--- a/feedspora.yml.template
+++ b/feedspora.yml.template
@@ -14,6 +14,7 @@ accounts:
     consumer_secret: 'my_consumer_secret'
     access_token: 'my_access_token'
     access_token_secret: 'my_access_token_scret'
+    max_posts: 1 # [optional] if > 0, defines the maximum number of entrys to post on a per-run basis.  If < 0, does not post, but puts the entry in the "published" database, allowing you to "seed" the database, especially useful when first starting up posting of a feed with a lot of entries.  If 0, essentially disables both posting and making entries to the "published" database (useful for seeing what might be published from the selected feed(s))
 
   - name: 'Facebook'
     type: 'FacebookClient'

--- a/feedspora.yml.template
+++ b/feedspora.yml.template
@@ -14,7 +14,7 @@ accounts:
     consumer_secret: 'my_consumer_secret'
     access_token: 'my_access_token'
     access_token_secret: 'my_access_token_scret'
-    max_posts: 1 # [optional] if > 0, defines the maximum number of entrys to post on a per-run basis.  If < 0, does not post, but puts the entry in the "published" database, allowing you to "seed" the database, especially useful when first starting up posting of a feed with a lot of entries.  If 0, essentially disables both posting and making entries to the "published" database (useful for seeing what might be published from the selected feed(s))
+    max_posts: 1 # [optional] if > 0, defines the maximum number of entrys to post on a per-run basis.  If < 0, does not post, but puts the entry in the "published" database, allowing you to "seed" the database, especially useful when first starting up posting of a feed with a lot of entries.  If 0 or not specified, unlimited postings/run are allowed
 
   - name: 'Facebook'
     type: 'FacebookClient'

--- a/src/feedspora/feedspora_runner.py
+++ b/src/feedspora/feedspora_runner.py
@@ -160,6 +160,14 @@ class GenericClient(object):
                 self._posts_done += 1
             return to_return
 
+    def seeding_published_db(self, item_num): 
+        '''
+        Override to post not being published, but marking it as published
+        in the DB anyway ("seeding" the published DB)
+        :param item_num:
+        '''
+        return ((self._max_posts < 0) and ((item_num + self._max_posts) <= 0))
+
 
 class FacebookClient(GenericClient):
     """ The FacebookClient handles the connection to Facebook. """
@@ -461,7 +469,7 @@ class FeedSpora(object):
                                   "' to client '" + client.__class__.__name__ +
                                   "': " + format(error))
                     continue
-               if (posted_to_client or client.seeding_published_db(item_num)):
+                if (posted_to_client or client.seeding_published_db(item_num)):
                     try:
                         self.add_to_published_entries(entry, client)
                     except Exception as error:


### PR DESCRIPTION
Enhancement to existing functionality to limit the number of Twitter posts (tweets) to the specified max_posts value (if >0), or with no limits if 0 or max_posts is not specified.  If specified max_posts < 0, does not post (tweet), but still adds the entry into the "published" database, allowing one to "seed" this database with any subset of existing stream entries (especially useful when first setting up the configuration).
This enhancement has been implemented in a client-generic way;  identical functionality can be added to any/all other client types simply by adding in code to set this value in the client's init code.