### PR TITLE
Enhancement/twitter post media

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,17 @@ FROM python:3.6
 LABEL maintainer="Strubbl-dockerfile@linux4tw.de"
 
 ENV DATA_DIR /data
+ENV MEDIA_DIR $DATA_DIR/media
 RUN \
-     mkdir $DATA_DIR \
+  mkdir $DATA_DIR \
+  && mkdir -p $MEDIA_DIR \
   && pip install git+https://github.com/aurelg/shaarpy.git \
   && git clone https://github.com/aurelg/feedspora.git \
   && cd feedspora \
   && pip install -r requirements.txt \
   && python setup.py install
 
+VOLUME $DATA_DIR
 WORKDIR $DATA_DIR
 CMD ["python", "-m", "feedspora"]
 

--- a/feedspora.yml.template
+++ b/feedspora.yml.template
@@ -15,6 +15,7 @@ accounts:
     access_token: 'my_access_token'
     access_token_secret: 'my_access_token_scret'
     max_posts: 1 # [optional] if > 0, defines the maximum number of entrys to post on a per-run basis.  If < 0, does not post, but puts the entry in the "published" database, allowing you to "seed" the database, especially useful when first starting up posting of a feed with a lot of entries.  If 0 or not specified, unlimited postings/run are allowed
+    post_include_media: true # [optional] if specified, image media from RSS feed sources will attempt to be included as part of the posted tweet
 
   - name: 'Facebook'
     type: 'FacebookClient'

--- a/src/feedspora/feedspora_runner.py
+++ b/src/feedspora/feedspora_runner.py
@@ -244,7 +244,7 @@ class TweepyClient(GenericClient):
         # Include media?
         self._include_media = False
         if ('post_include_media' in account):
-            self._include_media = (account['post_include_media'].lower() == "true")
+            self._include_media = account['post_include_media']
 
     def post(self, entry):
         """ Post entry to Twitter. """
@@ -583,7 +583,12 @@ class FeedSpora(object):
                 (entry.find('media:content')['medium'] == 'image')):
                 fse.media_url = entry.find('media:content')['url']
             elif (entry.find('img') is not None):
+                # TODO: handle possibility of an incomplete URL (prepend link
+                #       site root)
                 fse.media_url = entry.find('img')['src']
+            # TODO: additional measures to retrieve "buried" image 
+            #       specifications, such as within CDATA constructs of
+            #       content or description tags
             yield fse
 
     def _process_feed(self, feed_url):


### PR DESCRIPTION
Enhancement to existing functionality to optionally include image media from RSS feed entries as part of the posted tweet.  This is enabled by including a post_include_media setting of true within the relevant TweepyClient specification in feedspora.yml.  There is more work to be done on this for the general case (as noted by TODO comments), but this is working well for RSS streams with a fully-qualified URL specification within the media:content url tag (such as http://www.wildkidz.com/feed/factoid.php).
Inclusion of image media requires download of that media to a local directory, specified with the MEDIA_DIR environmental variable (defaulting to /tmp if this is not specified).
Updates have been made to the Dockerfile to include specification of the MEDIA_DIR env var, creating/pointing to a media subdirectory of DATA_DIR.