### PR TITLE
Optionally employ URL shortener services for Twitter links posted.

### DIFF
--- a/feedspora.yml.template
+++ b/feedspora.yml.template
@@ -14,6 +14,7 @@ accounts:
     consumer_secret: 'my_consumer_secret'
     access_token: 'my_access_token'
     access_token_secret: 'my_access_token_scret'
+    url_shortener: 'None' # [optional] defines the URL shortener that will attempt to be applied to the tweet's URL (if this fails for any reason, the original link is used instead).  Supported choices include 'Chilpit', 'Clkru', 'Dagd', 'Isgd', 'Osdb', 'Qpsru','Readability', 'Sentala', 'Soogd', and 'Tinyurl'.
     max_posts: 1 # [optional] if > 0, defines the maximum number of entrys to post on a per-run basis.  If < 0, does not post, but puts the entry in the "published" database, allowing you to "seed" the database, especially useful when first starting up posting of a feed with a lot of entries.  If 0 or not specified, unlimited postings/run are allowed
     post_include_media: true # [optional] if specified, image media from RSS feed sources will attempt to be included as part of the posted tweet
     post_include_content: true # [optional] if specified, the content of the RSS feed sources (if present) will be included within the posted tweet.  Any hashtags at the end of this content will be removed and processed separately

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ readability
 PyReadability
 shaarpy
 python3-linkedin
+pyshorteners
 lxml


### PR DESCRIPTION
Enabled via the optional TweepyClient url_shortener variable setting, an attempt at shortening the URL link to include in the tweet is made, using the specified service.  If this attempt fails for any reason, the unmodified link is used instead.
Supported URL shortening services include 'Chilpit', 'Clkru', 'Dagd', 'Isgd', 'Osdb', 'Qpsru', 'Readability', 'Sentala', 'Soogd', and 'Tinyurl' - case does not matter, and any other setting is silently ignored and no URL shortening is applied.