### PR TITLE
Modifications to improve testability

### DIFF
--- a/src/feedspora/__main__.py
+++ b/src/feedspora/__main__.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Post from Atom/RSS feeds to various client types.')
     parser.add_argument('-t', '--testing', nargs='?',
-                        const='feedspora', default=None
+                        const='feedspora', default=None,
                         help='execute test runs; no actual posting done')
     args = parser.parse_args()
 

--- a/src/feedspora/__main__.py
+++ b/src/feedspora/__main__.py
@@ -40,6 +40,8 @@ if __name__ == '__main__':
     # root name of config and DB files, optionally modified by the --testing
     # argument value (if present)
     root_name = 'feedspora'
+    if args.testing:
+        root_name = args.testing
     
     config = read_config_file(root_name+'.yml')
     feedspora = FeedSpora()

--- a/src/feedspora/__main__.py
+++ b/src/feedspora/__main__.py
@@ -39,9 +39,7 @@ if __name__ == '__main__':
 
     # root name of config and DB files, optionally modified by the --testing
     # argument value (if present)
-    root_name = 'feedspora'
-    if args.testing:
-        root_name = args.testing
+    root_name = args.testing if args.testing else 'feedspora'
     
     config = read_config_file(root_name+'.yml')
     feedspora = FeedSpora()

--- a/src/feedspora/__main__.py
+++ b/src/feedspora/__main__.py
@@ -4,6 +4,7 @@ Created on Nov 2, 2015
 @author: Aurelien Grosdidier
 @contact: aurelien.grosdidier@gmail.com
 '''
+import argparse
 import logging
 from feedspora.feedspora_runner import FeedSpora
 from feedspora.feedspora_runner import DiaspyClient  # @UnusedImport
@@ -28,26 +29,40 @@ def read_config_file(filename):
 
 
 if __name__ == '__main__':
-    config = read_config_file('feedspora.yml')
+    # Parse input args
+    parser = argparse.ArgumentParser(
+        description='Post from Atom/RSS feeds to various client types.')
+    parser.add_argument('-t', '--testing', nargs='?',
+                        const='feedspora', default=None
+                        help='execute test runs; no actual posting done')
+    args = parser.parse_args()
+
+    # root name of config and DB files, optionally modified by the --testing
+    # argument value (if present)
+    root_name = 'feedspora'
+    
+    config = read_config_file(root_name+'.yml')
     feedspora = FeedSpora()
     feedspora.set_feed_urls(config['feeds'])
 
-    def connect_account(account):
+    def connect_account(account, testing):
         '''
         Initialize a client for the specified account
         Then register it in FeedSpora
         :param account:
+        :param testing:
         '''
         try:
             client_class = globals()[account['type']]
-            client = client_class(account)
+            client = client_class(account, testing)
             client.set_name(account['name'])
+            client.set_testing_root(testing)
             feedspora.connect(client)
         except Exception as e:
             logging.error('Cannot connect {} : {}'.format(account['name'],
                                                           str(e)))
     for account in config['accounts']:
         if 'enabled' not in account or account['enabled']:
-            connect_account(account)
-    feedspora.set_db_file('feedspora.db')
+            connect_account(account, args.testing)
+    feedspora.set_db_file(root_name+'.db')
     feedspora.run()

--- a/src/feedspora/feedspora_runner.py
+++ b/src/feedspora/feedspora_runner.py
@@ -312,7 +312,7 @@ class GenericClient:
         Print output for testing purposes
         :param: text
         '''
-        print(output)
+        print(text)
         return True
 
     def test_output(self, text):
@@ -597,7 +597,7 @@ class WPClient(GenericClient):
         '''
         output = '>>> '+self.get_name()+' posting:\n'+ \
                  'Title: '+entry.title+'\n'+ \
-                 'post_tag: '+','.join(entry.keywords)+'\n'+ \
+                 'post_tag: '+', '.join(entry.keywords)+'\n'+ \
                  'category: AutomatedPost\n'+ \
                  'status: publish\n'+ \
                  'Content: '+text
@@ -611,7 +611,7 @@ class WPClient(GenericClient):
             urlparse(entry.link).netloc, self.get_content(entry.link))
         to_return = False
         if self.is_testing():
-            to_return = self.test_output(entry, content)
+            to_return = self.test_output(entry, post_content)
         else:
             # get text with readability
             post = WordPressPost()
@@ -655,7 +655,7 @@ class MastodonClient(GenericClient):
         :param: text
         '''
         output = '>>> '+self.get_name()+' posting:\n'+ \
-                 'Delay: '+delay+'\n'+ \
+                 'Delay: '+str(delay)+'\n'+ \
                  'Visibility: '+visibility+'\n'+ \
                  'Content: '+text
         return self.output_test(output)
@@ -695,7 +695,7 @@ class ShaarpyClient(GenericClient):
         output = '>>> '+self.get_name()+' posting:\n'+ \
                  'Title: '+title+'\n'+ \
                  'Link: '+link+'\n'+ \
-                 'Keywords: '+' ,'.join(keywords)+'\n'+ \
+                 'Keywords: '+', '.join(keywords)+'\n'+ \
                  'Content: '+text
         return self.output_test(output)
 

--- a/src/feedspora/feedspora_runner.py
+++ b/src/feedspora/feedspora_runner.py
@@ -336,6 +336,7 @@ class FacebookClient(GenericClient):
     _post_as = None
 
     def __init__(self, account, testing):
+        profile = None
         if not testing:
             self._graph = facebook.GraphAPI(account['token'])
             profile = self._graph.get_object('me')
@@ -377,7 +378,6 @@ class FacebookClient(GenericClient):
 
 class TweepyClient(GenericClient):
     """ The TweepyClient handles the connection to Twitter. """
-
     _api = None
 
     def __init__(self, account, testing):
@@ -385,6 +385,7 @@ class TweepyClient(GenericClient):
         # handle auth
         # See https://tweepy.readthedocs.org/en/v3.2.0/auth_tutorial.html
         # #auth-tutorial
+        auth = None
         if not testing:
             auth = tweepy.OAuthHandler(account['consumer_token'],
                                        account['consumer_secret'])
@@ -515,10 +516,11 @@ class TweepyClient(GenericClient):
 
 class DiaspyClient(GenericClient):
     """ The DiaspyClient handles the connection to Diaspora. """
+    stream = None
 
     def __init__(self, account, testing):
         """ Should be self-explaining. """
-        self.stream = None
+        connection = None
         if not testing:
             self.connection = diaspy.connection.Connection(
                 pod=account['pod'],
@@ -559,6 +561,7 @@ class DiaspyClient(GenericClient):
 
 class WPClient(GenericClient):
     """ The WPClient handles the connection to Wordpress. """
+    client = None
 
     def __init__(self, account, testing):
         """ Should be self-explaining. """

--- a/src/feedspora/feedspora_runner.py
+++ b/src/feedspora/feedspora_runner.py
@@ -321,7 +321,7 @@ class GenericClient:
         per-client basis - this is the default), then output that definition
         :param: text
         '''
-        output = '>>> '+self.get_name()+' posting:\n'+
+        output = '>>> '+self.get_name()+' posting:\n'+ \
                  'Content: '+text
         return self.output_test(output)
          
@@ -353,9 +353,9 @@ class FacebookClient(GenericClient):
         :param: attachment
         :param: post_as
         '''
-        output = '>>> '+self.get_name()+' posting as '+post_as+':\n'+
-                 'Name: '+attachment['name']+':\n'+
-                 'Link: '+attachment['link']+':\n'+
+        output = '>>> '+self.get_name()+' posting as '+post_as+':\n'+ \
+                 'Name: '+attachment['name']+':\n'+ \
+                 'Link: '+attachment['link']+':\n'+ \
                  'Content: '+text
         return self.output_test(output)
     
@@ -427,7 +427,7 @@ class TweepyClient(GenericClient):
         :param: text
         :param: media_path
         '''
-        output = '>>> '+self.get_name()+' posting:\n'+
+        output = '>>> '+self.get_name()+' posting:\n'+ \
                  'Content: '+text
         if media_path:
             output += '\nMedia: '+media_path
@@ -595,11 +595,11 @@ class WPClient(GenericClient):
         Print output for testing purposes
         :param: text
         '''
-        output = '>>> '+self.get_name()+' posting:\n'+
-                 'Title: '+entry.title+'\n'+
-                 'post_tag: '+','.join(entry.keywords)+'\n'+
-                 'category: AutomatedPost\n'+
-                 'status: publish\n'+
+        output = '>>> '+self.get_name()+' posting:\n'+ \
+                 'Title: '+entry.title+'\n'+ \
+                 'post_tag: '+','.join(entry.keywords)+'\n'+ \
+                 'category: AutomatedPost\n'+ \
+                 'status: publish\n'+ \
                  'Content: '+text
         return self.output_test(output)
 
@@ -654,9 +654,9 @@ class MastodonClient(GenericClient):
         :param: visibility
         :param: text
         '''
-        output = '>>> '+self.get_name()+' posting:\n'+
-                 'Delay: '+delay+'\n'+
-                 'Visibility: '+visibility+'\n'+
+        output = '>>> '+self.get_name()+' posting:\n'+ \
+                 'Delay: '+delay+'\n'+ \
+                 'Visibility: '+visibility+'\n'+ \
                  'Content: '+text
         return self.output_test(output)
 
@@ -692,10 +692,10 @@ class ShaarpyClient(GenericClient):
         Print output for testing purposes
         :param: text
         '''
-        output = '>>> '+self.get_name()+' posting:\n'+
-                 'Title: '+title+'\n'+
-                 'Link: '+link+'\n'+
-                 'Keywords: '+' ,'.join(keywords)+'\n'+
+        output = '>>> '+self.get_name()+' posting:\n'+ \
+                 'Title: '+title+'\n'+ \
+                 'Link: '+link+'\n'+ \
+                 'Keywords: '+' ,'.join(keywords)+'\n'+ \
                  'Content: '+text
         return self.output_test(output)
 
@@ -737,11 +737,11 @@ class LinkedInClient(GenericClient):
         :param: entry
         :param: visibility
         '''
-        output = '>>> '+self.get_name()+' posting:\n'+
-                 'Title: '+trim_string(entry.title, 200)+'\n'+
-                 'Link: '+entry.link+'\n'+
-                 'Visibility: '+visibility+'\n'+
-                 'Description: '+trim_string(entry.title, 256)+'\n'+
+        output = '>>> '+self.get_name()+' posting:\n'+ \
+                 'Title: '+trim_string(entry.title, 200)+'\n'+ \
+                 'Link: '+entry.link+'\n'+ \
+                 'Visibility: '+visibility+'\n'+ \
+                 'Description: '+trim_string(entry.title, 256)+'\n'+ \
                  'Comment: '+mkrichtext(entry.title, entry.keywords, maxlen=700)
         return self.output_test(output)
 

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
 function execute_tests() {
   test_dir=$1
   for config in `ls ${test_dir}/*.yml`; do

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+function execute_tests() {
+  test_dir=$1
+  for config in `ls ${test_dir}/*.yml`; do
+    filename=$(basename -- "$config")
+    test="${filename%.*}"
+    echo "    $test..."
+    rm -f ${test_dir}/${test}.out ${test_dir}/${test}.log ${test_dir}/${test}.db
+    (cd ${test_dir} && python -m feedspora --testing $test > ${test}.out 2> ${test}.log)
+    grep 'ERROR:' ${test_dir}/${test}.log
+  done
+}
+
+test_feed=0
+test_post=0
+show_usage=0
+if [ "X$1" = "X" ]; then
+  echo "No tests specified - aborting"
+  show_usage=1
+elif [ "$1" = "all" ]; then
+  echo "Executing all tests"
+  test_feed=1
+  test_post=1
+elif [ "$1" = "feed" ]; then
+  test_feed=1
+elif [ "$1" = "post" ]; then
+  test_post=1
+else
+  echo "Unknown test specification '$1' - aborting"
+  show_usage=1
+fi
+if [ $show_usage == 1 ]; then
+  echo "$0 all | feed | post"
+  exit 1
+fi
+if [ $test_feed == 1 ]; then
+  echo "Executing feed tests"
+  execute_tests "test_feed"
+fi
+if [ $test_post == 1 ]; then
+  echo "Executing post tests"
+  execute_tests "test_post"
+fi
+echo "All specified tests executed"
+

--- a/tests/test_feed/atom.yml
+++ b/tests/test_feed/atom.yml
@@ -1,0 +1,14 @@
+accounts:
+
+  - name: 'Twitter_full'
+    type: 'TweepyClient'
+    consumer_token: 'my_consumer_token'
+    consumer_secret: 'my_consumer_secret'
+    access_token: 'my_access_token'
+    access_token_secret: 'my_access_token_secret'
+    post_include_media: true
+    post_include_content: true
+
+
+feeds:
+  - '../feed.atom'

--- a/tests/test_feed/rss.yml
+++ b/tests/test_feed/rss.yml
@@ -1,0 +1,14 @@
+accounts:
+
+  - name: 'Twitter_full'
+    type: 'TweepyClient'
+    consumer_token: 'my_consumer_token'
+    consumer_secret: 'my_consumer_secret'
+    access_token: 'my_access_token'
+    access_token_secret: 'my_access_token_secret'
+    post_include_media: true
+    post_include_content: true
+
+
+feeds:
+  - '../feed.rss'

--- a/tests/test_post/basic.yml
+++ b/tests/test_post/basic.yml
@@ -1,0 +1,46 @@
+accounts:
+
+  - name: 'Diaspora_basic'
+    type: 'DiaspyClient'
+    pod: 'diaspora_pod_url'
+    username: 'username'
+    password: 'password'
+
+  - name: 'Twitter_basic'
+    type: 'TweepyClient'
+    consumer_token: 'my_consumer_token'
+    consumer_secret: 'my_consumer_secret'
+    access_token: 'my_access_token'
+    access_token_secret: 'my_access_token_secret'
+
+  - name: 'Facebook_basic'
+    type: 'FacebookClient'
+    token: 'your_facebook_token'
+
+  - name: 'Mastodon_basic'
+    type: 'MastodonClient'
+    client_id: 'client_key'
+    client_secret: 'client_secret'
+    access_token: 'access_token'
+    url: 'base_url_mastodon'
+
+  - name: 'Shaarpy_basic'
+    type: 'ShaarpyClient'
+    username: 'shaarli username'
+    password: 'shaarli password'
+    url: 'https://shaarli_url/u/shaarli_username/'
+
+  - name: 'WordPress_basic'
+    type: 'WPClient'
+    wpurl: 'some_random_url'
+    username: 'username'
+    password: 'password'
+
+  - name: 'LinkedIn_basic'
+    type: 'LinkedInClient'
+    authentication_token: 'authentication_token'
+    visibility: 'anyone'
+
+feeds:
+  - '../feed.atom'
+  - '../feed.rss'

--- a/tests/test_post/full.yml
+++ b/tests/test_post/full.yml
@@ -1,0 +1,58 @@
+accounts:
+
+  - name: 'Diaspora_full'
+    type: 'DiaspyClient'
+    pod: 'diaspora_pod_url'
+    username: 'username'
+    password: 'password'
+    keywords: 'hashtag1,hashtag2'
+
+  - name: 'Twitter_full'
+    type: 'TweepyClient'
+    consumer_token: 'my_consumer_token'
+    consumer_secret: 'my_consumer_secret'
+    access_token: 'my_access_token'
+    access_token_secret: 'my_access_token_secret'
+    url_shortener: 'Tinyurl'
+    max_posts: 3
+    max_tags: 4
+    post_prefix: 'BEGIN-'
+    post_suffix: '-END'
+    post_include_media: true
+    post_include_content: true
+
+  - name: 'Facebook_full'
+    type: 'FacebookClient'
+    token: 'your_facebook_token'
+    post_as: 'yomama'
+
+  - name: 'Mastodon_full'
+    type: 'MastodonClient'
+    client_id: 'client_key'
+    client_secret: 'client_secret'
+    access_token: 'access_token'
+    url: 'base_url_mastodon'
+    delay: 10
+    visibility: 'private'
+
+  - name: 'Shaarpy_full'
+    type: 'ShaarpyClient'
+    username: 'shaarli username'
+    password: 'shaarli password'
+    url: 'https://shaarli_url/u/shaarli_username/'
+
+  - name: 'WordPress_full'
+    type: 'WPClient'
+    wpurl: 'some_random_url'
+    username: 'username'
+    password: 'password'
+    keywords: 'hashtagA,hashtagB'
+
+  - name: 'LinkedIn_full'
+    type: 'LinkedInClient'
+    authentication_token: 'authentication_token'
+    visibility: 'connections-only'
+
+feeds:
+  - '../feed.atom'
+  - '../feed.rss'


### PR DESCRIPTION
Added optional command-line argument -t/--testing to indicate a test-only run, which generates client-specific text output instead of posting to the respective client.  A value can also be provided to this argument, which will influence the default configuration file name (feedspora.yml) and published DB name (feedspora.db).
If running in this test mode, no connections to the clients are made, setting the stage for automated testing of all clients/feeds without the security risk associated with client API keys or other such information to be present in the config files.
Finally, an initial test structure for using this new mechanism has been established, which includes both client-specific testing (with sub-options basic and full) and feed-specific testing (with sub-options atom and rss).  A *NIX bash shell script is also provided to drive these new tests.