### PR TITLE
Enhance RSS parser to capture image URLs within content or description elements

### DIFF
--- a/src/feedspora/feedspora_runner.py
+++ b/src/feedspora/feedspora_runner.py
@@ -1040,6 +1040,45 @@ class FeedSpora:
                 fse.published_date = entry.find('published').text
             yield fse
 
+    def find_rss_image_url(self, entry, link):
+        '''
+        Extract specified image URL, if it exists in the item (entry)
+        :param: entry
+        :param: link
+        '''
+        def content_img_src(entity):
+            result = None
+            for content in entity.contents:
+                img_tag = re.search(r'<img [^>]*src=["\']([^"\']+)["\']',
+                                    content)
+                if img_tag:
+                    result = img_tag.group(1)
+                    break
+            return result
+
+        to_return = None
+
+        if entry.find('media:content') and \
+           entry.find('media:content')['medium'] == 'image':
+            to_return = entry.find('media:content')['url']
+        elif entry.find('content'):
+            to_return = content_img_src(entry.find('content'))
+        elif entry.find('description'):
+            to_return = content_img_src(entry.find('description'))
+        if to_return and link:
+            tag_pattern = r'^(https?://[^/]+)/'
+            match_result = re.search(tag_pattern, to_return)
+            if not match_result:
+                # Not a full URL, need to adjust using link
+                match_result = re.search(tag_pattern, link)
+                if match_result:
+                    url_root = match_result.group(1)
+                    if to_return.startswith("/"):
+                        to_return = url_root+to_return
+                    else:
+                        to_return = url_root+"/"+to_return
+        return to_return
+
     # Define generator for RSS
     def parse_rss(self, soup):
         """ Generate FeedSpora entries out of a RSS feed. """
@@ -1072,16 +1111,7 @@ class FeedSpora:
                     fse.keywords.append(new_keyword)
 
             # And for our final act, media
-            if entry.find('media:content') and entry.find(
-                    'media:content')['medium'] == 'image':
-                fse.media_url = entry.find('media:content')['url']
-            elif entry.find('img'):
-                # TODO: handle possibility of an incomplete URL (prepend link
-                #       site root)
-                fse.media_url = entry.find('img')['src']
-            # TODO: additional measures to retrieve "buried" image
-            #       specifications, such as within CDATA constructs of
-            #       content or description tags
+            fse.media_url = self.find_rss_image_url(entry, fse.link)
             yield fse
 
     def _process_feed(self, feed_url):


### PR DESCRIPTION
This cleans up a couple of TODO items that have been in the code to capture image data from RSS streams.
The first was to correctly parse data within either the content or description elements (usually withing a CDATA structure) to find any `<img>` specification and capture its specified `src=` attribute.
The second was to detect any image URL data that was not fully specified as a complete URL (instead being a relative URL), and in this case, the `<link>` data associated with the item entry is leveraged to fill in the missing information.
The end result is that RSS feeds that include image data within their items are now more likely to capture and post that data (subject to user-specified client options).  And the pylint score is now at 8.83 with the removal of the TODO items!