### PR TITLE
Resync my dev with upstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           name: Setup VirtualEnv
           command: |
-            echo 'export TAG=0.1.${CIRCLE_BUILD_NUM}' >> $BASH_ENV
+            echo 'export TAG=${CIRCLE_SHA1}' >> $BASH_ENV
             echo 'export IMAGE_NAME=feedspora' >> $BASH_ENV 
 
       # Download and cache dependencies
@@ -89,10 +89,13 @@ jobs:
             PUBLIC_REPO=`echo $CIRCLE_REPOSITORY_URL | sed -e 's~:~/~' -e 's~git@~https://~'`
             docker build --build-arg GIT_REPO=$PUBLIC_REPO \
                          --build-arg GIT_REPO_REV=$CIRCLE_SHA1 \
-                         -t $DOCKERHUB_USERNAME/$IMAGE_NAME:latest \
                          -t $DOCKERHUB_USERNAME/$IMAGE_NAME:$TAG .
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
             docker push $DOCKERHUB_USERNAME/$IMAGE_NAME:$TAG
-            docker push $DOCKERHUB_USERNAME/$IMAGE_NAME:latest
-
+            if [ "X$CIRCLECI_BRANCH" == "Xdev" ]; then
+                # "latest" tag can ONLY come from the "dev" branch!
+                docker tag $DOCKERHUB_USERNAME/$IMAGE_NAME:$TAG \
+                           $DOCKERHUB_USERNAME/$IMAGE_NAME:latest
+                docker push $DOCKERHUB_USERNAME/$IMAGE_NAME:latest
+            fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
           command: |
             . venv/bin/activate
             docker build -t $DOCKERHUB_USERNAME/$IMAGE_NAME:$TAG .
-            echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
+            docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
             docker push $DOCKERHUB_USERNAME/$IMAGE_NAME:$TAG
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,12 +90,16 @@ jobs:
             docker build --build-arg GIT_REPO=$PUBLIC_REPO \
                          --build-arg GIT_REPO_REV=$CIRCLE_SHA1 \
                          -t $DOCKERHUB_USERNAME/$IMAGE_NAME:$TAG .
+            echo "Docker build complete"
             docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
             docker push $DOCKERHUB_USERNAME/$IMAGE_NAME:$TAG
-            if [ "X$CIRCLECI_BRANCH" == "Xdev" ]; then
+            echo "Docker push complete"
+            if [ "X$CIRCLE_BRANCH" == "Xdev" ]; then
                 # "latest" tag can ONLY come from the "dev" branch!
+                echo "Tagging/pushing image tag $TAG as 'latest'"
                 docker tag $DOCKERHUB_USERNAME/$IMAGE_NAME:$TAG \
                            $DOCKERHUB_USERNAME/$IMAGE_NAME:latest
                 docker push $DOCKERHUB_USERNAME/$IMAGE_NAME:latest
             fi
+            echo "All Docker build/push operations complete"
 


### PR DESCRIPTION
The only substantial changes are to the CircleCI config, to modify the tagging of produced images, limiting any tagging of "latest" to builds within the "dev" branch.  No functionality changes to Feedspora.